### PR TITLE
Linking libdl to Crypto in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ endif(BUILD_STATIC)
 # Needs abseil
 find_package(absl REQUIRED)
 target_link_libraries(compressor absl::status absl::strings)
-target_link_libraries(crypto absl::status absl::strings)
+target_link_libraries(crypto absl::status absl::strings dl)
 target_link_libraries(fvt_controller absl::strings)
 target_link_libraries(malign_buffer absl::strings)
 target_link_libraries(silkscreen absl::status absl::strings)


### PR DESCRIPTION
make was failing on my machine (RHEL 8) with the following error. Crypto uses libdl, which wasn't linked in the cmake list.
```
[ 92%] Linking CXX executable cpu_check
/usr/local/lib64/libcrypto.a(libcrypto-lib-dso_dlfcn.o): In function `dlfcn_globallookup':
dso_dlfcn.c:(.text+0x11): undefined reference to `dlopen'
dso_dlfcn.c:(.text+0x24): undefined reference to `dlsym'
dso_dlfcn.c:(.text+0x2f): undefined reference to `dlclose'
/usr/local/lib64/libcrypto.a(libcrypto-lib-dso_dlfcn.o): In function `dlfcn_bind_func':
dso_dlfcn.c:(.text+0x37c): undefined reference to `dlsym'
dso_dlfcn.c:(.text+0x47e): undefined reference to `dlerror'
/usr/local/lib64/libcrypto.a(libcrypto-lib-dso_dlfcn.o): In function `dlfcn_load':
dso_dlfcn.c:(.text+0x4f1): undefined reference to `dlopen'
dso_dlfcn.c:(.text+0x578): undefined reference to `dlclose'
dso_dlfcn.c:(.text+0x5b1): undefined reference to `dlerror'
/usr/local/lib64/libcrypto.a(libcrypto-lib-dso_dlfcn.o): In function `dlfcn_pathbyaddr':
dso_dlfcn.c:(.text+0x671): undefined reference to `dladdr'
dso_dlfcn.c:(.text+0x6d1): undefined reference to `dlerror'
/usr/local/lib64/libcrypto.a(libcrypto-lib-dso_dlfcn.o): In function `dlfcn_unload':
dso_dlfcn.c:(.text+0x732): undefined reference to `dlclose'
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [CMakeFiles/cpu_check.dir/build.make:138: cpu_check] Error 1
make[1]: *** [CMakeFiles/Makefile2:227: CMakeFiles/cpu_check.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```